### PR TITLE
Feature/fix promise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "cordova-plugin-tts",
+  "version": "0.4.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-tts",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Cordova Text-to-Speech Plugin",
   "cordova": {
     "id": "cordova-plugin-tts",

--- a/src/android/TTS.java
+++ b/src/android/TTS.java
@@ -208,9 +208,6 @@ public class TTS extends CordovaPlugin implements OnInitListener {
         }
 
         tts.speak(text, TextToSpeech.QUEUE_FLUSH, ttsParams);
-
-        final PluginResult result = new PluginResult(PluginResult.Status.OK, voice.toString());
-        callbackContext.sendPluginResult(result);
     }
 
     private Voice getVoiceByName(String voiceName) {


### PR DESCRIPTION
our custom plugin was returning an OK status result in Java when `speak` was called. However, this was causing the promise on JS to resolve simply because the utterance was added to the queue. By default, this plugin has an utterance progress listener that sends back a success response once the speech is fully processed / finished. By removing this return, it now relies solely on resolving when fully finished. Tested with Android on Cordova and works like a charm.